### PR TITLE
build: unify component name of pages

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "web",
+  "name": "laf-web",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "laf-web",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@element-plus/icons-vue": "^1.1.4",
         "@vicons/carbon": "^0.12.0",
@@ -35,6 +39,7 @@
         "balanced-match": "*",
         "eslint": "^8.15.0",
         "jsdom": "^19.0.0",
+        "magic-string": "^0.26.2",
         "pnpm": "^7.0.1",
         "postcss-nested": "^5.0.6",
         "typescript": "^4.6.4",
@@ -42,9 +47,14 @@
         "unplugin-auto-import": "^0.8.7",
         "unplugin-vue-components": "^0.19.6",
         "vite": "^2.9.8",
+        "vite-plugin-inspect": "^0.5.1",
         "vite-plugin-pages": "^0.23.0",
         "vitest": "^0.12.4",
         "vue-tsc": "^0.34.12"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">= 6.0.0"
       }
     },
     "node_modules/@antfu/eslint-config": {
@@ -3825,6 +3835,12 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmmirror.com/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "17.0.42",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-17.0.42.tgz",
@@ -4143,12 +4159,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/@unocss/preset-icons/node_modules/kolorist": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmmirror.com/kolorist/-/kolorist-1.5.1.tgz",
-      "integrity": "sha512-lxpCM3HTvquGxKGzHeknB/sUjuVoUElLlfYnXZT73K8geR9jQbroGlSCFBax9/0mpGoD3kzcMLnOlGQPJJNyqQ==",
-      "dev": true
-    },
     "node_modules/@unocss/preset-icons/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
@@ -4211,12 +4221,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@unocss/preset-icons/node_modules/ufo": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmmirror.com/ufo/-/ufo-0.8.4.tgz",
-      "integrity": "sha512-/+BmBDe8GvlB2nIflWasLLAInjYG0bC9HRnfEpNi4sw77J2AJNnEVnTDReVrehoh825+Q/evF3THXTAweyam2g==",
-      "dev": true
     },
     "node_modules/@unocss/preset-icons/node_modules/undici": {
       "version": "5.4.0",
@@ -4289,12 +4293,6 @@
         "ufo": "^0.8.4",
         "undici": "^5.2.0"
       }
-    },
-    "node_modules/@unocss/preset-web-fonts/node_modules/ufo": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmmirror.com/ufo/-/ufo-0.8.4.tgz",
-      "integrity": "sha512-/+BmBDe8GvlB2nIflWasLLAInjYG0bC9HRnfEpNi4sw77J2AJNnEVnTDReVrehoh825+Q/evF3THXTAweyam2g==",
-      "dev": true
     },
     "node_modules/@unocss/preset-web-fonts/node_modules/undici": {
       "version": "5.4.0",
@@ -7238,6 +7236,12 @@
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
     },
+    "node_modules/kolorist": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/kolorist/-/kolorist-1.5.1.tgz",
+      "integrity": "sha512-lxpCM3HTvquGxKGzHeknB/sUjuVoUElLlfYnXZT73K8geR9jQbroGlSCFBax9/0mpGoD3kzcMLnOlGQPJJNyqQ==",
+      "dev": true
+    },
     "node_modules/laf-client-sdk": {
       "version": "0.8.2",
       "resolved": "https://registry.npmmirror.com/laf-client-sdk/-/laf-client-sdk-0.8.2.tgz",
@@ -8462,6 +8466,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ufo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmmirror.com/ufo/-/ufo-0.8.4.tgz",
+      "integrity": "sha512-/+BmBDe8GvlB2nIflWasLLAInjYG0bC9HRnfEpNi4sw77J2AJNnEVnTDReVrehoh825+Q/evF3THXTAweyam2g==",
+      "dev": true
+    },
     "node_modules/unimport": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/unimport/-/unimport-0.2.9.tgz",
@@ -8768,6 +8778,25 @@
         "stylus": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-inspect": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmmirror.com/vite-plugin-inspect/-/vite-plugin-inspect-0.5.1.tgz",
+      "integrity": "sha512-cSVdNhVPAfH3OdVSV331/t/YWjg++HR/KiBkVST8pjLISna7O8gRwU8NN7KLrEBJqKKQqoRYLBb0RSdYurEyeg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^4.2.1",
+        "debug": "^4.3.4",
+        "kolorist": "^1.5.1",
+        "sirv": "^2.0.2",
+        "ufo": "^0.8.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "vite": "^2.9.0 || ^3.0.0-0"
       }
     },
     "node_modules/vite-plugin-pages": {
@@ -12342,6 +12371,12 @@
         "@types/lodash": "*"
       }
     },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmmirror.com/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "17.0.42",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-17.0.42.tgz",
@@ -12599,12 +12634,6 @@
           "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
           "dev": true
         },
-        "kolorist": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmmirror.com/kolorist/-/kolorist-1.5.1.tgz",
-          "integrity": "sha512-lxpCM3HTvquGxKGzHeknB/sUjuVoUElLlfYnXZT73K8geR9jQbroGlSCFBax9/0mpGoD3kzcMLnOlGQPJJNyqQ==",
-          "dev": true
-        },
         "locate-path": {
           "version": "6.0.0",
           "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
@@ -12654,12 +12683,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "ufo": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmmirror.com/ufo/-/ufo-0.8.4.tgz",
-          "integrity": "sha512-/+BmBDe8GvlB2nIflWasLLAInjYG0bC9HRnfEpNi4sw77J2AJNnEVnTDReVrehoh825+Q/evF3THXTAweyam2g==",
           "dev": true
         },
         "undici": {
@@ -12732,12 +12755,6 @@
             "ufo": "^0.8.4",
             "undici": "^5.2.0"
           }
-        },
-        "ufo": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmmirror.com/ufo/-/ufo-0.8.4.tgz",
-          "integrity": "sha512-/+BmBDe8GvlB2nIflWasLLAInjYG0bC9HRnfEpNi4sw77J2AJNnEVnTDReVrehoh825+Q/evF3THXTAweyam2g==",
-          "dev": true
         },
         "undici": {
           "version": "5.4.0",
@@ -15071,6 +15088,12 @@
       "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
       "dev": true
     },
+    "kolorist": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/kolorist/-/kolorist-1.5.1.tgz",
+      "integrity": "sha512-lxpCM3HTvquGxKGzHeknB/sUjuVoUElLlfYnXZT73K8geR9jQbroGlSCFBax9/0mpGoD3kzcMLnOlGQPJJNyqQ==",
+      "dev": true
+    },
     "laf-client-sdk": {
       "version": "0.8.2",
       "resolved": "https://registry.npmmirror.com/laf-client-sdk/-/laf-client-sdk-0.8.2.tgz",
@@ -16023,6 +16046,12 @@
       "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "devOptional": true
     },
+    "ufo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmmirror.com/ufo/-/ufo-0.8.4.tgz",
+      "integrity": "sha512-/+BmBDe8GvlB2nIflWasLLAInjYG0bC9HRnfEpNi4sw77J2AJNnEVnTDReVrehoh825+Q/evF3THXTAweyam2g==",
+      "dev": true
+    },
     "unimport": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/unimport/-/unimport-0.2.9.tgz",
@@ -16204,6 +16233,19 @@
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
+      }
+    },
+    "vite-plugin-inspect": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmmirror.com/vite-plugin-inspect/-/vite-plugin-inspect-0.5.1.tgz",
+      "integrity": "sha512-cSVdNhVPAfH3OdVSV331/t/YWjg++HR/KiBkVST8pjLISna7O8gRwU8NN7KLrEBJqKKQqoRYLBb0RSdYurEyeg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^4.2.1",
+        "debug": "^4.3.4",
+        "kolorist": "^1.5.1",
+        "sirv": "^2.0.2",
+        "ufo": "^0.8.4"
       }
     },
     "vite-plugin-pages": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,6 +40,7 @@
     "balanced-match": "*",
     "eslint": "^8.15.0",
     "jsdom": "^19.0.0",
+    "magic-string": "^0.26.2",
     "pnpm": "^7.0.1",
     "postcss-nested": "^5.0.6",
     "typescript": "^4.6.4",
@@ -47,6 +48,7 @@
     "unplugin-auto-import": "^0.8.7",
     "unplugin-vue-components": "^0.19.6",
     "vite": "^2.9.8",
+    "vite-plugin-inspect": "^0.5.1",
     "vite-plugin-pages": "^0.23.0",
     "vitest": "^0.12.4",
     "vue-tsc": "^0.34.12"

--- a/packages/web/scripts/extend-route.ts
+++ b/packages/web/scripts/extend-route.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'path'
+import type { RouteRecordRaw } from 'vue-router'
+import { resolveComponentNameByPath } from './utils'
+
+/**
+ * 所有路由自动增加 meta 信息，对应路由的组件名
+ * @param route
+ * @returns
+ */
+export default function extendRoute(route: RouteRecordRaw) {
+  if (!route.component)
+    return route
+  const fileName = route.component as any as string
+  const routeName = route.name as string
+  // update route.name
+  route.name = routeName.split('-').join('.')
+  // update route.meta
+  route.meta = {
+    ...route.meta,
+    componentName: resolveComponentNameByPath(resolve(process.cwd(), `.${fileName}`)),
+  }
+  return route
+}

--- a/packages/web/scripts/utils.ts
+++ b/packages/web/scripts/utils.ts
@@ -1,0 +1,27 @@
+import { basename, relative, resolve } from 'path'
+
+export function toCamcelCase(str: string) {
+  const s: string[] = []
+  for (let i = 0; i < str.length; i++) {
+    if (i === 0 || str[i - 1] === '-' || str[i - 1] === '_')
+      s.push(str[i].toUpperCase())
+
+    else if (str[i] !== '-' && str[i] !== '_')
+      s.push(str[i])
+  }
+  return s.join('')
+}
+
+export function resolveComponentNameByPath(id: string) {
+  const dir = resolve(process.cwd(), 'src')
+  const path = relative(dir, id)
+    .replace(/\.vue$/, '') // remove suffix
+    .replace(/\[([.]{3})*(?<name>\S+)\]/g, '$<name>') // remove dynamic params
+  const parts = path.split('/')
+  return parts.map(toCamcelCase).join('.')
+}
+
+export function resolveComponentNameByFileName(id: string) {
+  const path = basename(id, '.vue')
+  return toCamcelCase(path)
+}

--- a/packages/web/scripts/vite-plugin-vue-sfc-name.ts
+++ b/packages/web/scripts/vite-plugin-vue-sfc-name.ts
@@ -1,0 +1,70 @@
+import { relative } from 'path'
+import type { Plugin } from 'vite'
+
+import { compileScript, parse } from '@vue/compiler-sfc'
+import MagicString from 'magic-string'
+import { resolveComponentNameByFileName, resolveComponentNameByPath } from './utils'
+
+/**
+ * 探测所有的页面，并根据页面路径生成页面组件的 name
+ * pages/account/login.vue -> Pages.Account.Login
+ * @reference vite-plugin-vue-setup-extend-plus
+ */
+export default (): Plugin => {
+  return {
+    name: 'vite:vue-page-name',
+    enforce: 'pre',
+    async transform(code, id) {
+      if (!/\.vue$/.test(id))
+        return null
+
+      if (!id.includes('pages') || id.includes('components'))
+        return null
+
+      return injectScript(code, id, 'path')
+    },
+  }
+}
+
+const componentNameResolvers = {
+  path: resolveComponentNameByPath,
+  file: resolveComponentNameByFileName,
+}
+
+export function injectScript(code: string, id: string, type: 'file' | 'path') {
+  const s = new MagicString(code)
+  const FILENAME_RE = /.*\/(\S*)/
+  const { descriptor } = parse(code)
+  if (!descriptor.script && descriptor.scriptSetup) {
+    const result = compileScript(descriptor, { id })
+    const { name, lang, noDefaultName, inheritAttrs } = result.attrs
+    const shouldDefineName = name || !noDefaultName
+    if (shouldDefineName || inheritAttrs) {
+      s.appendLeft(
+        0,
+        `<script ${lang ? `lang="${lang}"` : ''}>
+import { defineComponent } from 'vue'
+// id: ${relative(process.cwd(), id)}
+export default defineComponent({
+  ${shouldDefineName ? `name: "${name || componentNameResolvers[type](id)}",` : ''}
+  ${inheritAttrs ? `inheritAttrs: ${inheritAttrs !== 'false'},` : ''}
+})
+</script>\n`,
+      )
+    }
+
+    const map = s.generateMap({ hires: true })
+    const filename = FILENAME_RE.exec(id)![1]
+
+    map.file = filename
+    map.sources = [filename]
+
+    return {
+      map,
+      code: s.toString(),
+    }
+  }
+  else {
+    return null
+  }
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -10,6 +10,9 @@ import AutoImport from 'unplugin-auto-import/vite'
 import Unocss from 'unocss/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 import vueI18n from '@intlify/vite-plugin-vue-i18n'
+import Inspect from 'vite-plugin-inspect'
+import SFCName from './scripts/vite-plugin-vue-sfc-name'
+import extendRoute from './scripts/extend-route'
 
 export default defineConfig({
   resolve: {
@@ -18,6 +21,9 @@ export default defineConfig({
     },
   },
   plugins: [
+    // debug plugins only
+    // Inspect(),
+    SFCName(),
     Vue({
       reactivityTransform: true,
     }),
@@ -34,26 +40,12 @@ export default defineConfig({
 
     // https://github.com/hannoeru/vite-plugin-pages
     Pages({
+      extendRoute,   
       dirs: [
         { dir: path.resolve(__dirname, './src/pages'), baseRoute: '' },
         { dir: path.resolve(__dirname, './src/pages/account'), baseRoute: '' },
       ],
-      exclude: ['**/components/**.vue'],
-      // extensions: ['.vue', '.js', '.ts'],
-      // extendRoute(route: any) {
-      //   if (route.name === 'about')
-      //     route.props = (route: any) => ({ query: route.query.q })
-
-      //   if (route.name === 'components') {
-      //     return {
-      //       ...route,
-      //       beforeEnter: (route: any) => {
-      //         // eslint-disable-next-line no-console
-      //         console.log(route)
-      //       },
-      //     }
-      //   }
-      // },
+      exclude: ['**/components/**.vue','**/*.ts'],
     }),
 
     Layouts({


### PR DESCRIPTION
+ 编写vite插件，根据路径，自动给页面级组件统一命名
+ 同时修改编译时的路由元信息，使得组件名和路由信息进行关联

上面的举措用于方便后期支持多tab访问。