### PR TITLE
fix: page route

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -72,7 +72,7 @@ const guideSiderbarConfig = [
   {
     text: '静态网站托管',
     items: [
-      { text: '静态托管简介', link: '/guide/website-hosting/index' },
+      { text: '静态托管简介', link: '/guide/website-hosting/' },
       { text: '快速开始', link: '/guide/website-hosting/quick-start' },
     ]
   },


### PR DESCRIPTION
修复页面配置导致的底部下一页不对的问题
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/972813/180402875-87a3c31d-8334-4499-a44d-7519dfd5ffe0.png">
