### PR TITLE
feat: add more app status process for release action

### DIFF
--- a/packages/system-server/src/handler/application/remove.ts
+++ b/packages/system-server/src/handler/application/remove.ts
@@ -2,7 +2,7 @@
  * @Author: Maslow<wangfugen@126.com>
  * @Date: 2021-08-30 15:22:34
  * @LastEditTime: 2022-01-19 14:48:50
- * @Description: 
+ * @Description:
  */
 
 import * as assert from 'assert'
@@ -45,7 +45,7 @@ export async function handleRemoveApplication(req: Request, res: Response) {
     return res.status(403).send('only owner can remove application')
   }
 
-  if (app.status !== 'stopped') {
+  if (app.status !== 'stopped' && app.status !== 'created') {
     return res.status(400).send('you should stopped application instance before removing')
   }
 

--- a/packages/web/src/pages/apps/components/AppTable.vue
+++ b/packages/web/src/pages/apps/components/AppTable.vue
@@ -187,11 +187,20 @@ const toDetail = (app: any) => {
           <el-button type="default" size="small" @click="$emit('showImportDialog', row)">
             导入
           </el-button>
-          <el-tooltip v-if="type === 'created'" content="释放即完全删除应用，暂不可恢复，谨慎操作，仅应用创建者可执行此操作!" effect="light" placement="left">
-            <el-button :disabled="row.status === 'running'" size="small" type="default" @click="deleteApp(row)">
-              释放
-            </el-button>
-          </el-tooltip>
+          <template v-if="type === 'created'">
+            <el-tooltip v-if="row.status === 'stopped' || row.status === 'created'" content="释放即完全删除应用，暂不可恢复，谨慎操作，仅应用创建者可执行此操作!" effect="light" placement="left">
+              <el-button size="small" type="default" @click="deleteApp(row)">
+                释放
+              </el-button>
+            </el-tooltip>
+            <el-tooltip v-else content="请先停止应用" effect="light" placement="left">
+              <div class="inline-block ml-12px">
+                <el-button :disabled="true" size="small" type="default" @click="deleteApp(row)">
+                  释放
+                </el-button>
+              </div>
+            </el-tooltip>
+          </template>
         </template>
       </el-table-column>
     </el-table>

--- a/packages/web/src/pages/apps/components/AppTable.vue
+++ b/packages/web/src/pages/apps/components/AppTable.vue
@@ -189,9 +189,13 @@ const toDetail = (app: any) => {
           </el-button>
           <template v-if="type === 'created'">
             <el-tooltip v-if="row.status === 'stopped' || row.status === 'created'" content="释放即完全删除应用，暂不可恢复，谨慎操作，仅应用创建者可执行此操作!" effect="light" placement="left">
-              <el-button size="small" type="default" @click="deleteApp(row)">
-                释放
-              </el-button>
+              <el-popconfirm title="确认要释放应用吗？该操作不可撤回" cancel-button-text="否" confirm-button-text="是" @confirm="deleteApp(row)">
+                <template #reference>
+                  <el-button size="small" type="default">
+                    释放
+                  </el-button>
+                </template>
+              </el-popconfirm>
             </el-tooltip>
             <el-tooltip v-else content="请先停止应用" effect="light" placement="left">
               <div class="inline-block ml-12px">


### PR DESCRIPTION
- add more `app.status` type. because backend cannot release `starting/etc...` status
  those request will return 400 response
  now disable it.
- add new tooltip for disable case, tell user the reason of why we
  cannot release
- add popconfirm for this action, its danger action, we should reconfirm it
- allow created app delete

## old
![image](https://user-images.githubusercontent.com/6964737/184054854-4bbb3c79-c972-479e-9501-11ee9c014ce6.png)


## now
![image](https://user-images.githubusercontent.com/6964737/184054767-df2f74b5-7c10-42ec-9170-c6b2c074d8f7.png)

![image](https://user-images.githubusercontent.com/6964737/184056010-e7ab7e0c-a856-4604-b256-74644331177c.png)
