### PR TITLE
fix: 查看日志打不开

### DIFF
--- a/packages/web/src/pages/app/[appid]/cloudfunction/components/DebugPanel.vue
+++ b/packages/web/src/pages/app/[appid]/cloudfunction/components/DebugPanel.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
       调用参数
     </div>
     <div class="h-300px">
-      <JsonEditor v-model="invokeParams" :line-numbers="false" :height="300" :dark="false" />
+      <JsonEditor v-model="invokeParams" :line-numbers="false" :height="100" :dark="false" />
     </div>
     <div v-if="props.invokeRequestId" class="invoke-result">
       <div class="title">
@@ -25,7 +25,7 @@ const props = defineProps<{
       </div>
       <div v-if="invokeLogs" class="logs">
         <div v-for="(log, index) in invokeLogs" :key="index" class="log-item">
-          <pre>- {{ log }}</pre>
+          <pre class="text-sm">- {{ log }}</pre>
         </div>
       </div>
       <div class="title" style="margin-top: 20px">
@@ -33,7 +33,7 @@ const props = defineProps<{
         <span v-if="props.invokeTimeUsage"> （ {{ props.invokeTimeUsage }} ms ）</span>
       </div>
       <div class="result overflow-auto">
-        <pre>{{ props.invokeResult }}</pre>
+        <pre class="text-sm">{{ props.invokeResult }}</pre>
       </div>
     </div>
   </div>

--- a/packages/web/src/pages/app/[appid]/cloudfunction/index.vue
+++ b/packages/web/src/pages/app/[appid]/cloudfunction/index.vue
@@ -437,7 +437,7 @@ async function handleChange(funcId: string, value: any) {
           </el-tooltip>
         </template>
       </el-table-column>
-      <el-table-column label="操作" align="center" min-width="180">
+      <el-table-column label="操作" align="center" min-width="200">
         <template #default="{ row, $index }">
           <el-button type="success" plain size="small" @click="handleShowDetail(row)">
             开发

--- a/packages/web/src/pages/app/[appid]/cloudfunction/logs/index.vue
+++ b/packages/web/src/pages/app/[appid]/cloudfunction/logs/index.vue
@@ -138,7 +138,7 @@ function setTagViewTitle() {
         </el-table-column> -->
       <el-table-column label="操作" align="center" width="100" class-name="small-padding fixed-width">
         <template #default="{ row }">
-          <el-button size="small" type="primary" @click="handleShowDetail(row)">
+          <el-button plain size="small" type="primary" @click="handleShowDetail(row)">
             查看
           </el-button>
         </template>

--- a/packages/web/src/pages/app/[appid]/cloudfunction/triggers/[funcId].vue
+++ b/packages/web/src/pages/app/[appid]/cloudfunction/triggers/[funcId].vue
@@ -178,7 +178,7 @@ async function handleDelete(row: any, index: number) {
 
 function showTriggerLogs(row: any) {
   router.push({
-    name: '日志',
+    name: '日志查询',
     query: {
       trigger_id: row._id,
     },
@@ -271,13 +271,13 @@ onMounted(async () => {
       </el-table-column>
       <el-table-column label="操作" align="center" class-name="small-padding fixed-width">
         <template #default="{ row, $index }">
-          <el-button type="info" @click="showTriggerLogs(row)">
+          <el-button plain size="small" type="info" @click="showTriggerLogs(row)">
             日志
           </el-button>
-          <el-button type="primary" @click="showUpdateForm(row)">
+          <el-button plain size="small" type="primary" @click="showUpdateForm(row)">
             编辑
           </el-button>
-          <el-button v-if="row.status !== 'deleted'" type="danger" @click="handleDelete(row, $index)">
+          <el-button v-if="row.status !== 'deleted'" plain size="small" type="danger" @click="handleDelete(row, $index)">
             删除
           </el-button>
         </template>


### PR DESCRIPTION
1. 修复日志页面打不开的问题，现在 
<img width="253" alt="image" src="https://user-images.githubusercontent.com/972813/184469736-71720a60-f9f9-46ea-b893-78d47391e9da.png">
是依据这个 `name` 来生成页面的路由 name，但是这个现在是菜单和路由公用，后面需要增加一个专门给 route 用的 name

2. 优化了下页面的显示，有些地方按扭太大，改成 size="small" 和 plain 样式