### PR TITLE
feat(web): fix functionPannel & dataPannel

### DIFF
--- a/web/src/components/CopyText/index.tsx
+++ b/web/src/components/CopyText/index.tsx
@@ -8,12 +8,13 @@ import useGlobalStore from "@/pages/globalStore";
 export default function CopyText(props: {
   text: string;
   tip?: string;
+  className?: string;
   children?: React.ReactElement;
 }) {
   const { onCopy, setValue } = useClipboard("");
   const { showSuccess } = useGlobalStore();
 
-  const { children = <CopyIcon />, text, tip } = props;
+  const { children = <CopyIcon />, text, tip, className } = props;
 
   useEffect(() => {
     setValue(text);
@@ -22,7 +23,7 @@ export default function CopyText(props: {
   return (
     <Tooltip label={t("ToolTip.Copy")} placement="top">
       {React.cloneElement(children, {
-        className: "ml-2",
+        className: "ml-2 " + (className || ""),
         onClick: () => {
           onCopy();
           showSuccess(tip || t("ToolTip.Copied"));

--- a/web/src/pages/app/database/CollectionDataList/index.tsx
+++ b/web/src/pages/app/database/CollectionDataList/index.tsx
@@ -2,9 +2,9 @@ import { Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 
 import RightPanel from "../../mods/RightPanel";
 
-import ColPannel from "./mods/ColPannel";
+// import ColPannel from "./mods/ColPannel";
 import DataPannel from "./mods/DataPannel";
-import IndexPannel from "./mods/IndexPannel";
+// import IndexPannel from "./mods/IndexPannel";
 
 export default function CollectionDataList() {
   return (
@@ -12,19 +12,19 @@ export default function CollectionDataList() {
       <Tabs className="h-full">
         <TabList>
           <Tab>数据管理</Tab>
-          <Tab>索引管理</Tab>
-          <Tab>集合结构</Tab>
+          {/* <Tab>索引管理</Tab>
+          <Tab>集合结构</Tab> */}
         </TabList>
         <TabPanels className="h-full">
           <TabPanel className="overflow-hidden relative" style={{ height: "calc(100% - 55px)" }}>
             <DataPannel />
           </TabPanel>
-          <TabPanel>
+          {/* <TabPanel>
             <IndexPannel />
           </TabPanel>
           <TabPanel className="overflow-hidden relative" style={{ height: "calc(100% - 35px)" }}>
             <ColPannel />
-          </TabPanel>
+          </TabPanel> */}
         </TabPanels>
       </Tabs>
     </RightPanel>

--- a/web/src/pages/app/database/CollectionDataList/mods/DataPannel/index.tsx
+++ b/web/src/pages/app/database/CollectionDataList/mods/DataPannel/index.tsx
@@ -10,13 +10,14 @@ import Pagination from "@/components/Pagination";
 import getPageInfo from "@/utils/getPageInfo";
 
 import { useAddDataMutation, useEntryDataQuery, useUpdateDataMutation } from "../../../service";
+import useDBMStore from "../../../store";
 
 import DeleteButton from "./DeleteButton";
 export default function DataPannel() {
   const [currentData, setCurrentData] = useState<any>(undefined);
 
   const [record, setRecord] = useState("");
-
+  const store = useDBMStore((state) => state);
   type FormData = {
     _id: string;
   };
@@ -71,9 +72,16 @@ export default function DataPannel() {
                   pointerEvents="none"
                   children={<Search2Icon color="gray.300" />}
                 />
-                <Input borderRadius="4" placeholder="_id" bg="white" {...register("_id")} />
+                <Input
+                  disabled={store.currentDB === undefined}
+                  borderRadius="4"
+                  placeholder="_id"
+                  bg="white"
+                  {...register("_id")}
+                />
               </InputGroup>
               <Button
+                disabled={store.currentDB === undefined}
                 px={9}
                 type={"submit"}
                 colorScheme={"green"}
@@ -86,6 +94,7 @@ export default function DataPannel() {
           </div>
         </form>
         <Button
+          disabled={store.currentDB === undefined}
           colorScheme={"primary"}
           size="sm"
           onClick={() => {

--- a/web/src/pages/app/database/CollectionListPanel/index.tsx
+++ b/web/src/pages/app/database/CollectionListPanel/index.tsx
@@ -21,6 +21,8 @@ export default function CollectionListPanel() {
     onSuccess: (data) => {
       if (data.data.length > 0) {
         store.setCurrentDB(data.data[0]);
+      } else {
+        store.setCurrentDB(undefined);
       }
     },
   });

--- a/web/src/pages/app/database/store.ts
+++ b/web/src/pages/app/database/store.ts
@@ -5,8 +5,8 @@ import { immer } from "zustand/middleware/immer";
 import { TDB } from "@/apis/typing";
 
 type State = {
-  currentDB?: TDB;
-  setCurrentDB: (currentDB: TDB) => void;
+  currentDB?: TDB | undefined;
+  setCurrentDB: (currentDB: TDB | undefined) => void;
 };
 
 const useDBMStore = create<State>()(

--- a/web/src/pages/app/functions/index.tsx
+++ b/web/src/pages/app/functions/index.tsx
@@ -5,7 +5,6 @@
 import { Badge, Button, Center, HStack } from "@chakra-ui/react";
 import { t } from "i18next";
 
-import CopyText from "@/components/CopyText";
 import FunctionEditor from "@/components/Editor/FunctionEditor";
 import FileTypeIcon, { FileType } from "@/components/FileTypeIcon";
 import PanelHeader from "@/components/Panel/Header";
@@ -75,12 +74,6 @@ function FunctionPage() {
                 </div>
 
                 <HStack spacing="4">
-                  {store.getFunctionUrl() !== "" && (
-                    <span>
-                      <span className=" text-slate-500">调用地址：{store.getFunctionUrl()}</span>
-                      <CopyText text={store.getFunctionUrl()} />
-                    </span>
-                  )}
                   <DeployButton />
                   <Button
                     size="sm"


### PR DESCRIPTION

<img width="349" alt="function" src="https://user-images.githubusercontent.com/27497945/209528152-7a7958e7-9706-4ad3-b8c8-65ae30978b73.png">

1. fix 云函数调试页面实际为 POST，显示为 GET

 2. fix 云函数调试地址可隐藏，与调用地址一致且重复

<img width="550" alt="database" src="https://user-images.githubusercontent.com/27497945/209528153-eb782fa2-9faf-4219-a75b-99a453ef3c96.png">

1. fix 去除/ 隐藏 索引管理 和集合结构 页面元素
2. fix 空数据时，需要处理 disable
