### PR TITLE
fix(runtime-nodejs): fix custom env unable to read

### DIFF
--- a/runtimes/nodejs/README.md
+++ b/runtimes/nodejs/README.md
@@ -29,12 +29,30 @@ cd runtimes/nodejs
 
 # proxy app cluster traffic to local, replace `APPID` with your prepared appid
 telepresence connect
-telepresence intercept APPID -n APPID -p 8000:8000 -e $(pwd)/.env
 
-# required nodejs version >= 18.0.0
+# Start local service first, required nodejs version >= 18.0.0
 npm install
 
 npm run build
 
 npm start
+# intercept
+telepresence intercept APPID -n APPID -p 8000:8000 -e $(pwd)/.env
+
+# after intercept command, you can use following command to check if intercept active
+telepresence list -n APPID
+# if success, you would see like below
+Your-APPID: intercepted
+   Intercept name         : APPID-APPID
+   State                  : ACTIVE
+   Workload kind          : Deployment
+   Destination            : 127.0.0.1:8000
+   Service Port Identifier: 8000
+   Intercepting           : all TCP requests
+```
+
+> Clean up
+
+```bash
+telepresence leave APPID-APPID
 ```

--- a/runtimes/nodejs/src/support/cloud-sdk.ts
+++ b/runtimes/nodejs/src/support/cloud-sdk.ts
@@ -29,14 +29,8 @@ function createCloudSdk() {
     env: {
       DB_URI: Config.DB_URI,
       SERVER_SECRET: Config.SERVER_SECRET,
-      APP_ID: process.env.APP_ID,
-      OSS_ACCESS_KEY: process.env.APP_ID,
-      OSS_ACCESS_SECRET: process.env.OSS_ACCESS_SECRET,
-      OSS_REGION: process.env.OSS_REGION,
-      OSS_INTERNAL_ENDPOINT: process.env.OSS_INTERNAL_ENDPOINT,
-      OSS_EXTERNAL_ENDPOINT: process.env.OSS_EXTERNAL_ENDPOINT,
-      NPM_INSTALL_FLAGS: process.env.NPM_INSTALL_FLAGS || '',
       RUNTIME_IMAGE: Config.RUNTIME_IMAGE,
+      ...process.env,
     },
   }
 


### PR DESCRIPTION
After add custom env, can not get value from `cloud.env`
Fix this bug by use `...process.env` code

**Note: This fix haven't be fully test:**
Update environment variable will restart app container, this method(using telepresence intercept) can not restart local container