### PR TITLE
feat(web): add confirm update env modal

### DIFF
--- a/web/public/locales/en/translation.json
+++ b/web/public/locales/en/translation.json
@@ -137,7 +137,8 @@
     "Expire": "Expiration",
     "Setting": "Setting",
     "SystemSetting": "Application Settings",
-    "UserSetting": "User Settings"
+    "UserSetting": "User Settings",
+    "UpdateConfirm": "Update env will restart application, are you sure?"
   },
   "StoragePanel": {
     "All": "Total Capacity",

--- a/web/public/locales/zh-CN/translation.json
+++ b/web/public/locales/zh-CN/translation.json
@@ -125,7 +125,8 @@
     "AppEnv": "环境变量",
     "AddAppEnv": "新增环境变量",
     "Expire": "过期时间",
-    "UserSetting": "用户设置"
+    "UserSetting": "用户设置",
+    "UpdateConfirm": "更新环境变量将重新启动应用，是否继续？"
   },
   "StoragePanel": {
     "CreateBucket": "创建 Bucket",

--- a/web/public/locales/zh/translation.json
+++ b/web/public/locales/zh/translation.json
@@ -137,7 +137,8 @@
     "Expire": "过期时间",
     "Setting": "设置",
     "SystemSetting": "应用设置",
-    "UserSetting": "用户设置"
+    "UserSetting": "用户设置",
+    "UpdateConfirm": "更新环境变量将重新启动应用，是否继续？"
   },
   "StoragePanel": {
     "All": "总容量",

--- a/web/src/components/ConfirmButton/index.tsx
+++ b/web/src/components/ConfirmButton/index.tsx
@@ -17,11 +17,17 @@ interface ConfirmButtonProps {
   onSuccessAction: () => void;
   headerText: string;
   bodyText: string;
-
+  confirmButtonText?: string;
   children: React.ReactElement;
 }
 
-const ConfirmButton = ({ onSuccessAction, headerText, bodyText, children }: ConfirmButtonProps) => {
+const ConfirmButton = ({
+  onSuccessAction,
+  headerText,
+  bodyText,
+  confirmButtonText,
+  children,
+}: ConfirmButtonProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = React.useRef<any>();
 
@@ -52,7 +58,9 @@ const ConfirmButton = ({ onSuccessAction, headerText, bodyText, children }: Conf
 
           <AlertDialogFooter>
             <Button colorScheme={"red"} onClick={onSubmit}>
-              {t("Delete")}
+              {confirmButtonText && confirmButtonText.length !== 0
+                ? confirmButtonText
+                : t("Delete")}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/web/src/pages/app/setting/AppEnvList/index.tsx
+++ b/web/src/pages/app/setting/AppEnvList/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@chakra-ui/react";
 import { t } from "i18next";
 
+import ConfirmButton from "@/components/ConfirmButton";
 import EditableTable from "@/components/EditableTable";
 import { isExitInList } from "@/utils/format";
 
@@ -74,17 +75,17 @@ const AppEnvList = (props: { onClose?: () => {} }) => {
           onDelete={(data) => delEnvironmentMutation.mutateAsync({ name: data })}
           onCreate={(data) => addEnvironmentMutation.mutateAsync(data)}
         />
-        <Button
-          className="w-28 h-8 self-end mt-4"
-          type="submit"
-          variant={"secondary"}
-          onClick={() => {
+        <ConfirmButton
+          onSuccessAction={() => {
             globalStore.restartCurrentApp();
             props.onClose && props.onClose();
           }}
+          headerText={String(t("Update"))}
+          bodyText={String(t("SettingPanel.UpdateConfirm"))}
+          confirmButtonText={String(t("Update"))}
         >
-          {t("Update")}
-        </Button>
+          <Button className="w-28 h-8 self-end mt-4">{t("Update")}</Button>
+        </ConfirmButton>
       </div>
     </>
   );


### PR DESCRIPTION

https://user-images.githubusercontent.com/37979965/219876568-10fb0038-3626-4c92-a416-6c20c2473350.mov


1. Update env will restart application, this operation needs to remind the user
2. ComfirmButton Component default confirm text is `delete`, add an `option` variable named `confirmButtonText` to replace defaut text