### PR TITLE
fix(web) : add port for functionUrl

### DIFF
--- a/web/src/apis/typing.d.ts
+++ b/web/src/apis/typing.d.ts
@@ -18,6 +18,7 @@ export type TApplication = {
   storage: Storage;
   tls: boolean;
   develop_token: string;
+  port: number;
 };
 
 export type TBundle = {

--- a/web/src/components/Editor/typesResolve/index.ts
+++ b/web/src/components/Editor/typesResolve/index.ts
@@ -7,7 +7,13 @@ import useGlobalStore from "@/pages/globalStore";
 
 async function loadPackageTypings(packageName: string) {
   const { currentApp } = useGlobalStore.getState();
-  const url = `//${currentApp?.domain?.domain}`;
+  const port = currentApp?.port;
+
+  let url = `//${currentApp?.domain?.domain}`;
+  if (port !== 80 && port !== 443) {
+    url = `${url}:${port}`;
+  }
+
   const res = await axios({
     url: `${url}/_/typing/package?packageName=${packageName}`,
     method: "GET",

--- a/web/src/pages/app/functions/store.ts
+++ b/web/src/pages/app/functions/store.ts
@@ -28,12 +28,19 @@ const useFunctionStore = create<State>()(
 
       getFunctionUrl: () => {
         const currentApp = useGlobalStore.getState().currentApp;
-        const currentFunction = get().currentFunction;
-        const protocol = currentApp?.tls ? "https://" : "http://";
+        const currentFunctionName = get().currentFunction?.name;
 
-        return currentFunction?.name
-          ? `${protocol}${currentApp?.domain?.domain}/${currentFunction?.name}`
-          : "";
+        if (!currentFunctionName) return "";
+
+        const protocol = currentApp?.tls ? "https://" : "http://";
+        const port = currentApp?.port;
+
+        let host = currentApp?.domain?.domain;
+        if (port !== 80 && port !== 443) {
+          host = `${host}:${port}`;
+        }
+
+        return `${protocol}${host}/${currentFunctionName}`;
       },
 
       setCurrentRequestId: (requestId) => {


### PR DESCRIPTION
端口不是 80 和 443 的情况下为函数的 url 添加上端口
![a78e87850a4ab2a1dcf20d8ca45f6d1](https://user-images.githubusercontent.com/82700206/221335400-b8bc0058-2139-4f93-9b31-6b1b28dae64e.png)
