### PR TITLE
ci(e2e): wait api route in apisix ready

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,12 @@ on:
   repository_dispatch:
     types: [cluster_image_build_success, dockerize_runtime_success]
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "e2e/**"
+      - ".github/workflows/e2e.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -15,6 +15,10 @@ fi
 
 API_ENDPOINT="http://api.${DOMAIN}"
 
+if [ -z "$GET_LAF_API_ROUTE_MAX_RETRY_COUNT" ]; then
+  GET_LAF_API_ROUTE_MAX_RETRY_COUNT=60
+fi
+
 if [ -z "${LAF_DEPLOYMENT_TIMEOUT}" ]; then
   LAF_DEPLOYMENT_TIMEOUT=180
 fi
@@ -76,13 +80,40 @@ MONGODB_PASSWORD=$(kubectl get secret --namespace laf-system mongodb-mongodb-ini
 echo "mongodb user is ${MONGODB_USER}"
 echo "mongodb passwd is ${MONGODB_PASSWORD}"
 
+APISIX_ADMIN_KEY=$(kubectl get configmap apisix-configmap -n laf-system -o jsonpath='{.data.config\.yaml}' | grep "default_cluster_admin_key" | awk -F': ' '{print $2}' | tr -d '"')
+echo "APISIX_ADMIN_KEY is ${APISIX_ADMIN_KEY}"
+
+############## Wait for Apisix api route ready ##############
+
+echo "================= Wait for Apisix api route ready ================="
+
+LAF_API_DOMAIN=api.$DOMAIN
+APISIX_ADMIN_URL=http://$DOMAIN:9180/apisix/admin
+
+get_api_roytes_retry_count=0
+
+while [ $get_api_roytes_retry_count -lt $GET_LAF_API_ROUTE_MAX_RETRY_COUNT ]
+do
+    response=$(curl -s $APISIX_ADMIN_URL/routes -H "X-API-KEY: $APISIX_ADMIN_KEY")
+    laf_api_route_exists=$(echo $response | jq '.node.nodes[].value.host' | grep -c $LAF_API_DOMAIN)
+    if [ $laf_api_route_exists -gt 0 ]
+    then
+        echo "Find route for $LAF_API_DOMAIN"
+        break
+    fi
+    echo "Can not Find route for $LAF_API_DOMAIN. Retrying in 1 second..."
+    sleep 1
+    get_api_roytes_retry_count=$((get_api_roytes_retry_count+1))
+done
+if [ $laf_api_route_exists -eq 0 ]
+then
+    echo "Can not Find route for $LAF_API_DOMAIN. Exit"
+    exit 1
+fi
+
 ############## Get Laf token ##############
 
 echo "================= Get Laf token ================="
-
-# somethimes even all apisix pods are ready but we still got "404 Route Not Found"
-# so we need to wait for a while to make sure apisix routes are ready
-sleep 15
 
 # set -e
 echo "Create a Laf user and get Laf token"


### PR DESCRIPTION
## Summary

1. wait api route in apisix ready
2. add more actions trigger

## Screenshoots

You can take a look at the execution result of this action. This is the result obtained when I temporarily changed the trigger condition to `pull request`: https://github.com/labring/laf/actions/runs/4800439541
