### PR TITLE
feat(web): add function params storage

### DIFF
--- a/web/src/apis/typing.d.ts
+++ b/web/src/apis/typing.d.ts
@@ -225,6 +225,7 @@ export type TFunction = {
   createdAt: string;
   updatedAt: string;
   createdBy: string;
+  params: any;
 };
 
 export type TMethod = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "OPTIONS" | "PATCH";

--- a/web/src/pages/app/functions/mods/DebugPanel/BodyParamsTab/index.tsx
+++ b/web/src/pages/app/functions/mods/DebugPanel/BodyParamsTab/index.tsx
@@ -39,8 +39,11 @@ const ContentType = {
   FORM_DATA: "multipart/form-data",
 };
 
-function BodyParamsTab(props: { onChange(values: { contentType: string; data: any }): void }) {
-  const { onChange } = props;
+function BodyParamsTab(props: {
+  onChange(values: { contentType: string; data: any }): void;
+  paramsList: { contentType: string; data: any };
+}) {
+  const { onChange, paramsList } = props;
   const { colorMode } = useColorMode();
 
   const [dataType, setDataType] = useState<string>(ContentType.JSON);
@@ -105,7 +108,7 @@ function BodyParamsTab(props: { onChange(values: { contentType: string; data: an
                 });
             } catch (e) {}
           }}
-          value={JSON.stringify({}, null, 2)}
+          value={JSON.stringify(paramsList?.data ?? {}, null, 2)}
         />
       ) : (
         <div>

--- a/web/src/pages/app/functions/mods/DebugPanel/QueryParamsTab/index.tsx
+++ b/web/src/pages/app/functions/mods/DebugPanel/QueryParamsTab/index.tsx
@@ -13,9 +13,9 @@ type FormValues = {
   params: Params[];
 };
 
-function HeaderParamsTab(props: { onChange(values: Params[]): void }) {
-  const { onChange } = props;
-  const { register, control, watch } = useForm<FormValues>({
+function HeaderParamsTab(props: { onChange(values: Params[]): void; paramsList: Params[] }) {
+  const { onChange, paramsList } = props;
+  const { register, control, watch, setValue } = useForm<FormValues>({
     defaultValues: {
       params: [{ name: "", value: "" }],
     },
@@ -33,6 +33,10 @@ function HeaderParamsTab(props: { onChange(values: Params[]): void }) {
     return () => subscription.unsubscribe();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [watch]);
+
+  useEffect(() => {
+    setValue("params", paramsList ?? []);
+  }, [setValue, paramsList]);
 
   return (
     <div>

--- a/web/src/pages/app/functions/mods/DebugPanel/index.tsx
+++ b/web/src/pages/app/functions/mods/DebugPanel/index.tsx
@@ -23,7 +23,7 @@ import Panel from "@/components/Panel";
 import Resize from "@/components/Resize";
 import { COLOR_MODE, Pages } from "@/constants";
 
-import { useCompileMutation } from "../../service";
+import { useCompileMutation, useUpdateFunctionMutation } from "../../service";
 import useFunctionStore from "../../store";
 
 import BodyParamsTab from "./BodyParamsTab";
@@ -43,6 +43,7 @@ export default function DebugPanel(props: { containerRef: any; showOverlay: bool
   const { getFunctionUrl, currentFunction, setCurrentRequestId } = useFunctionStore(
     (state) => state,
   );
+  const updateFunctionMutation = useUpdateFunctionMutation();
   const globalStore = useGlobalStore((state) => state);
 
   const functionCache = useFunctionCache();
@@ -82,6 +83,22 @@ export default function DebugPanel(props: { containerRef: any; showOverlay: bool
       const compileRes = await compileMutation.mutateAsync({
         code: functionCache.getCache(currentFunction!.id, currentFunction!.source?.code),
         name: currentFunction!.name,
+      });
+
+      const params = {
+        queryParams: queryParams,
+        bodyParams: bodyParams,
+        headerParams: headerParams,
+      };
+
+      updateFunctionMutation.mutateAsync({
+        description: currentFunction?.desc,
+        code: functionCache.getCache(currentFunction!.id, currentFunction!.source?.code),
+        methods: currentFunction?.methods,
+        websocket: currentFunction?.websocket,
+        name: currentFunction?.name,
+        tags: currentFunction?.tags,
+        params: params,
       });
 
       if (!compileRes.error) {
@@ -216,6 +233,7 @@ export default function DebugPanel(props: { containerRef: any; showOverlay: bool
                           onChange={(values: any) => {
                             setQueryParams(values);
                           }}
+                          paramsList={currentFunction.params?.queryParams}
                         />
                       </TabPanel>
 
@@ -229,6 +247,7 @@ export default function DebugPanel(props: { containerRef: any; showOverlay: bool
                             onChange={(values) => {
                               setBodyParams(values);
                             }}
+                            paramsList={currentFunction.params?.bodyParams}
                           />
                         </TabPanel>
                       )}
@@ -239,6 +258,7 @@ export default function DebugPanel(props: { containerRef: any; showOverlay: bool
                           onChange={(values: any) => {
                             setHeaderParams(values);
                           }}
+                          paramsList={currentFunction.params?.headerParams}
                         />
                       </TabPanel>
                     </TabPanels>


### PR DESCRIPTION
add params storage and code storage in runningCode

write code and params
![image](https://user-images.githubusercontent.com/71265218/236608330-e21c260d-988b-469f-9f42-73b5ee7160c4.png)

running  (Click the button or Ctrl+s)
![image](https://user-images.githubusercontent.com/71265218/236608554-388239c2-f933-405a-bcb1-8b7ba5ba6e20.png)

then the code and params  are stored on the server side