### PR TITLE
fix(cli): fix read function name error in windows

### DIFF
--- a/cli/src/action/function/index.ts
+++ b/cli/src/action/function/index.ts
@@ -297,7 +297,7 @@ function getLocalFunction(dir: string, prefix: string): string[] {
       funcNames.push(...getLocalFunction(filePath, path.join(prefix || '', file)))
     }
     if (stat.isFile() && file.endsWith('.ts')) {
-      funcNames.push(path.join(prefix || '', file).replace(/\.ts$/, ''))
+      funcNames.push(path.join(prefix || '', file).replace(/\\/g, '/').replace(/\.ts$/, ''))
     }
   })
   return funcNames


### PR DESCRIPTION
修复windows下拉取带目录的函数路径错误