### PR TITLE
fix(build): minio console ingress enable websocket

### DIFF
--- a/build/charts/minio/templates/console-ingress.yaml
+++ b/build/charts/minio/templates/console-ingress.yaml
@@ -3,6 +3,8 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  annotations:
+    k8s.apisix.apache.org/enable-websocket: "true"
   name: minio-console-ingress
 spec:
   # apisix-ingress-controller is only interested in Ingress


### PR DESCRIPTION
Add this annotation is use to enable websocket connections.

---
![image](https://github.com/labring/laf/assets/39112652/76d57715-e58e-4a2b-aac6-9ad50b230be1)
