### PR TITLE
chore: only show func name of last depth

### DIFF
--- a/web/src/pages/app/functions/mods/HeadPanel/index.tsx
+++ b/web/src/pages/app/functions/mods/HeadPanel/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { CloseIcon } from "@chakra-ui/icons";
-import { HStack, Input, useColorMode } from "@chakra-ui/react";
+import { HStack, Input, useColorMode, Tooltip } from "@chakra-ui/react";
 import clsx from "clsx";
 import SimpleBar from "simplebar-react";
 
@@ -72,7 +72,10 @@ function HeadPanel() {
                         functionItem={item}
                         color={selected ? "#00A9A6" : ""}
                       />
-                      <p className="truncate">{item.name}</p>
+                      <Tooltip label={item.name} placement="auto">
+                        <p className="truncate">{item.name.split('/').pop()}</p>
+                      </Tooltip>
+
                     </div>
                     {functionCache.getCache(item?._id, (item as any)?.source?.code) !==
                     (item as any)?.source?.code ? (


### PR DESCRIPTION
When cloud function name is directory like style, ( eg. /module1/sub1/sub3/read-func-name)

cloud function name display is inconvenient to read in Function head panel

only show func name of last depth may be a little better

![pr](https://github.com/labring/laf/assets/37979965/1a13229a-d3df-4dad-b74f-eaa67f220d83)
