### PR TITLE
fix(cli): func desc missing caused by typo

### DIFF
--- a/cli/src/action/function/index.ts
+++ b/cli/src/action/function/index.ts
@@ -82,7 +82,7 @@ async function pull(funcName: string) {
   const func = await functionControllerFindOne(appSchema.appid, urlencode(funcName))
   const functionSchema: FunctionSchema = {
     name: func.name,
-    description: func.description,
+    desc: func.desc,
     methods: func.methods,
     tags: func.tags,
   }
@@ -131,7 +131,7 @@ async function push(funcName: string, isCreate: boolean) {
   if (isCreate) {
     const createDto: CreateFunctionDto = {
       name: funcName,
-      description: funcSchema.description || '',
+      description: funcSchema.desc || '',
       methods: funcSchema.methods as any,
       code,
       tags: funcSchema.tags,
@@ -139,7 +139,7 @@ async function push(funcName: string, isCreate: boolean) {
     await functionControllerCreate(appSchema.appid, createDto)
   } else {
     const updateDto: UpdateFunctionDto = {
-      description: funcSchema.description || '',
+      description: funcSchema.desc || '',
       methods: funcSchema.methods as any,
       code,
       tags: funcSchema.tags,

--- a/cli/src/schema/function.ts
+++ b/cli/src/schema/function.ts
@@ -6,7 +6,7 @@ import { mkdirSync } from 'fs'
 
 export class FunctionSchema {
   name: string
-  description?: string
+  desc?: string
   tags?: string[]
   methods: string[]
 


### PR DESCRIPTION
## What Did the PR fixed

When we use laf-cli to push/pull functions, the **description** will be omitted.

In laf-cli schema, it's `description`:
<img width="412" alt="image" src="https://github.com/labring/laf/assets/36830265/3d51f1f4-1f14-4d2c-b4ac-78b9611ef6e5">

In api.laf,dev its's `desc`:
<img width="1451" alt="image" src="https://github.com/labring/laf/assets/36830265/e11d334b-1463-4ebc-8a22-c7dcab08b9ec">


## Screenshots after fixed

![3372917246](https://github.com/labring/laf/assets/36830265/befc3b35-5691-4ed8-a6c4-8476efd88f74)

## Furthermore

The deep-seated reason lies in the **inconsistency between the naming of the database and DTO in laf-server**. Perhaps this needs to be standardized.

<img width="1259" alt="image" src="https://github.com/labring/laf/assets/36830265/4e216fe2-6045-40ed-8dfe-bcc9d1c0cade">

<img width="1172" alt="image" src="https://github.com/labring/laf/assets/36830265/797cf596-779f-4969-b76a-255df2a39a6c">

