### PR TITLE
fix(cli): storage field key error during refresh

### DIFF
--- a/cli/src/schema/app.ts
+++ b/cli/src/schema/app.ts
@@ -46,10 +46,9 @@ export class AppSchema {
     }
 
     appSchema.storage = {
-      endpoint: app.storage.credentials.endpoint,
-      accessKeyId: app.storage.credentials.accessKeyId,
-      accessKeySecret: app.storage.credentials.secretAccessKey,
-      sessionToken: app.storage.credentials.sessionToken,
+      endpoint: app.storage.endpoint,
+      accessKeyId: app.storage.accessKey,
+      accessKeySecret: app.storage.secretKey,
       expire: timestamp + STORAGE_TOKEN_EXPIRE,
     }
 


### PR DESCRIPTION
## Reproduce

1. laf storage push/pull
2. storage token expired (the error only happen in storage token `refesh`)

<img width="725" alt="image" src="https://github.com/labring/laf/assets/36830265/b17aef06-dbb4-4b9a-b174-c8409496087b">

## Bug Fix

<img width="539" alt="image" src="https://github.com/labring/laf/assets/36830265/a6476cf1-0a2d-42cc-b59c-a1ffa4b3d0cc">


new schema of `app` by `console.log`

![660133556](https://github.com/labring/laf/assets/36830265/fb100e6e-fae4-413a-b4ad-b34a0b8964af)


## Screenshots after fixed

origin `.app.yaml`
<img width="886" alt="image" src="https://github.com/labring/laf/assets/36830265/26563e11-5f0f-4595-b0a8-4e6260cdc561">


<img width="359" alt="image" src="https://github.com/labring/laf/assets/36830265/35a84b32-95f7-4211-aabf-43b9c961f7b1">

`.app.yaml` after refresh

<img width="821" alt="image" src="https://github.com/labring/laf/assets/36830265/5ccd0fda-07e7-477b-a1d3-9ad189e2e501">
