### PR TITLE
docs: improve macOS deploy guide

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,7 +27,9 @@ sh install-on-linux.sh $DOMAIN
 brew install --cask multipass
 ```
 
-2. Create vm & deploy in it
+2. Grant `Settings -> Security & Privacy -> Full Disk Access` for multipassd
+
+3. Create vm & deploy in it
 
 ```bash
 cd deploy

--- a/deploy/install-on-mac.sh
+++ b/deploy/install-on-mac.sh
@@ -51,7 +51,7 @@ if multipass list | grep -e "^$NAME "; then
 fi
 
 echo "Creating VM..."
-echo "\tmultipass launch --name $NAME --cpus 2 --memory 4G --disk 40G"
+echo "\tmultipass launch --name $NAME --cpus 2 --memory 4G --disk 50G"
 multipass launch --name "$NAME" --cpus 2 --memory 4G --disk 50G 22.04
 # shellcheck disable=SC2181
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
1. improve deploy/README.md

We have to grant Full Disk Access for multipassd after brew install. Otherwise, we will get an error like `sh:0: cannot open /laf/deploy/install-on-linux.sh: Operation not permitted`.

I wanted to upload an image but failed. Sorry.

2. improve shell echo

Echo 40G but 50G actually.