### PR TITLE
feat: log request server automatically send an empty message

### DIFF
--- a/server/src/log/log.controller.ts
+++ b/server/src/log/log.controller.ts
@@ -138,12 +138,14 @@ export class LogController {
       const streamsEnded = new Set<string>()
 
       const timerId = setInterval(() => {
+        console.log("data send...")
         subscriber.next('data: \n' as unknown as MessageEvent)
       }, 60000)
 
       const destroyStream = () => {
         combinedLogStream?.removeAllListeners()
         combinedLogStream?.destroy()
+        console.log("clearInterval timerId")
         clearInterval(timerId)
       }
 

--- a/server/src/log/log.controller.ts
+++ b/server/src/log/log.controller.ts
@@ -137,9 +137,14 @@ export class LogController {
 
       const streamsEnded = new Set<string>()
 
+      const timerId = setInterval(() => {
+        subscriber.next('data: \n')
+      }, 60000)
+
       const destroyStream = () => {
         combinedLogStream?.removeAllListeners()
         combinedLogStream?.destroy()
+        clearInterval(timerId)
       }
 
       combinedLogStream.on('data', (chunk) => {

--- a/server/src/log/log.controller.ts
+++ b/server/src/log/log.controller.ts
@@ -138,7 +138,7 @@ export class LogController {
       const streamsEnded = new Set<string>()
 
       const timerId = setInterval(() => {
-        subscriber.next(' ' as unknown as MessageEvent)
+        subscriber.next('\u200B' as unknown as MessageEvent)
       }, 30000)
 
       const destroyStream = () => {

--- a/server/src/log/log.controller.ts
+++ b/server/src/log/log.controller.ts
@@ -138,14 +138,12 @@ export class LogController {
       const streamsEnded = new Set<string>()
 
       const timerId = setInterval(() => {
-        console.log("data send...")
-        subscriber.next('data: \n' as unknown as MessageEvent)
-      }, 60000)
+        subscriber.next(' ' as unknown as MessageEvent)
+      }, 30000)
 
       const destroyStream = () => {
         combinedLogStream?.removeAllListeners()
         combinedLogStream?.destroy()
-        console.log("clearInterval timerId")
         clearInterval(timerId)
       }
 

--- a/server/src/log/log.controller.ts
+++ b/server/src/log/log.controller.ts
@@ -138,7 +138,7 @@ export class LogController {
       const streamsEnded = new Set<string>()
 
       const timerId = setInterval(() => {
-        subscriber.next('data: \n')
+        subscriber.next('data: \n' as unknown as MessageEvent)
       }, 60000)
 
       const destroyStream = () => {


### PR DESCRIPTION
Keep sending empty messages so that log requests are not automatically disconnected